### PR TITLE
Enigma Encrypt Feature

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -4,12 +4,10 @@ class Enigma
     @char_array = ("a".."z").to_a << " "
   end
 
-  def encrypt(message, key = nil, date = nil)
-    char_slices.each do |char_slice|
-      char_slice.each_with_index do |char, index|
-
-      end
-    end
+  def encrypt(message, key = Array.new(5){rand(10)}.join, date = DateTime.now.strftime('%d%m%y'))
+    {encryption: joiner(message_shifter(message, key, date)),
+    key: key,
+    date: date}
   end
 
   def message_breakdown(message)
@@ -18,7 +16,7 @@ class Enigma
     char_slices
   end
 
-  def message_shifter(message, key = Array.new(5){rand(10)}.join, date = DateTime.now.strftime('%d%m%y'))
+  def message_shifter(message, key, date)
     shift_info = Shift.new(key, date)
     broken_message = message_breakdown(message)
     broken_message.map.with_index do |char_slice, index|
@@ -37,6 +35,10 @@ class Enigma
         char
       end
     end
+  end
+
+  def joiner(broken_message)
+      broken_message.flatten.join
   end
 
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,3 +1,43 @@
 class Enigma
 
+  def initialize
+    @char_array = ("a".."z").to_a << " "
+  end
+
+  def encrypt(message, key = nil, date = nil)
+    char_slices.each do |char_slice|
+      char_slice.each_with_index do |char, index|
+
+      end
+    end
+  end
+
+  def message_breakdown(message)
+    char_slices = []
+    message.downcase.chars.each_slice(4) {|mess_break| char_slices << mess_break}
+    char_slices
+  end
+
+  def message_shifter(message, key = Array.new(5){rand(10)}.join, date = DateTime.now.strftime('%d%m%y'))
+    shift_info = Shift.new(key, date)
+    broken_message = message_breakdown(message)
+    broken_message.map.with_index do |char_slice, index|
+      letter_shifter(char_slice, shift_info.shifts_table.values)
+    end
+  end
+
+  def letter_shifter(array, shift_amounts)
+    array.map.with_index do |char, index|
+      # require 'pry'; binding.pry
+      if @char_array.include?(char)
+        shifted = @char_array.rotate(shift_amounts[index])
+        char_index = @char_array.index(char)
+        char = shifted[char_index]
+      else
+        char
+      end
+    end
+  end
+
+
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -42,7 +42,6 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_encrypt_message_encrypts_and_returns_hash
-    skip
     expected = {
                   encryption: "keder ohulw",
                   key: "02715",
@@ -58,6 +57,44 @@ class EnigmaTest < Minitest::Test
 
     assert_equal ["b", "c", "d", "e"], @enigma.letter_shifter(array, [1, 1, 1, 1])
     assert_equal ["b", "c", ",", "e"], @enigma.letter_shifter(array2, [1, 1, 1, 1])
+  end
+
+  def test_broken_message_can_be_joined
+    broken = [["k", "e", "d", "e"], 
+              ["r", " ", "o", "h"],
+              ["u", "l", "w"]]
+
+    assert_equal "keder ohulw", @enigma.joiner(broken)
+  end
+
+  def test_encrypt_can_ignore_punctuation
+    expected = {
+                  encryption: "keder ohulw!",
+                  key: "02715",
+                  date: "040895"
+                }
+
+    assert_equal expected, @enigma.encrypt("hello world!", "02715", "040895")
+  end
+
+  def test_encryption_can_change_casing
+    expected = {
+                  encryption: "keder ohulw",
+                  key: "02715",
+                  date: "040895"
+                }
+
+    assert_equal expected, @enigma.encrypt("hello WORLD", "02715", "040895")
+  end
+
+  def test_encryption_can_handle_smaller_messages
+    expected = {
+                  encryption: "ked",
+                  key: "02715",
+                  date: "040895"
+                }
+
+    assert_equal expected, @enigma.encrypt("hel", "02715", "040895")
   end
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -7,8 +7,57 @@ class EnigmaTest < Minitest::Test
     @enigma = Enigma.new
   end
 
-  def test_enigma_exists
+  def test_enigma_exists_with_starting_attributes
     assert_instance_of Enigma, @enigma
+  end
+
+  def test_message_can_be_broken_down
+    message = "hello world"
+    expected = [["h", "e", "l", "l"], 
+                 ["o", " ", "w", "o"],
+                 ["r", "l", "d"]]
+
+    assert_equal expected, @enigma.message_breakdown(message)
+  end
+
+  def test_message_will_adjust_casing
+    message = "HELLO world"
+    expected = [["h", "e", "l", "l"], 
+                 ["o", " ", "w", "o"],
+                 ["r", "l", "d"]]
+
+    assert_equal expected, @enigma.message_breakdown(message)
+    
+  end
+
+  def test_message_can_be_shifted
+    message = "hello world"
+
+    expected = [["k", "e", "d", "e"], 
+              ["r", " ", "o", "h"],
+              ["u", "l", "w"]]
+
+
+    assert_equal expected, @enigma.message_shifter(message, "02715", "040895")
+  end
+
+  def test_encrypt_message_encrypts_and_returns_hash
+    skip
+    expected = {
+                  encryption: "keder ohulw",
+                  key: "02715",
+                  date: "040895"
+                }
+
+    assert_equal expected, @enigma.encrypt("hello world", "02715", "040895")
+  end
+
+  def test_letter_can_be_shifted
+    array = ['a', 'b', 'c', 'd']
+    array2 = ['a', 'b', ',', 'd']
+
+    assert_equal ["b", "c", "d", "e"], @enigma.letter_shifter(array, [1, 1, 1, 1])
+    assert_equal ["b", "c", ",", "e"], @enigma.letter_shifter(array2, [1, 1, 1, 1])
   end
 
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -11,9 +11,10 @@ class ShiftTest < Minitest::Test
   def test_it_exists_with_default_values_random_with_todays_date
     assert_instance_of Shift, @shift
 
-    today = DateTime.now.strftime('%d%m%y')
+    @shift.stubs(:date_info => 100120)
+    
     assert_equal 5, @shift.key.length
-    assert_equal today.to_i, @shift.date_info
+    assert_equal 100120, @shift.date_info
   end
 
   def test_can_pass_own_values


### PR DESCRIPTION
## Enigma Encrypt Method ##

Enigma's encrypt method is required to take a message but can also take a key and a date.  If those aren't provided ones will be made for it; randomly for the key and the current date for the date.

The Encrypt Method passes through 4 helper methods currently.

**Message Breakdown**
The message is iterated over and returns an array of arrays.  The inner arrays are at most 4 characters and each element is a single char from the message.

**Message Shifter**
The message, key, and date are currently passed into this method.  Here the individual arrays of chars are passed to a another method called letter shifter.  The return value of this method is another array of arrays, but these inner arrays contain the encoded chars.

**Letter Shifter**
This method takes in a single array of characters and the shift table.  It iterates over the array and changes the char based on the shift table amount.  If the char is something that shouldn't be encoded it isn't changed.

**Joiner**
Joiner takes the array of character arrays and flattens it then joins it together into the message.

The final part of the encrypt them makes a hash with the encoded message the key and the date.